### PR TITLE
Documentation update for maps package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ The library falls into a number of categories, subdivided into separate packages
     - [Ranges](#ranges)
   - [Simple Iterator](#simple-iterator)
 - [Maps](#maps)
+  - [Keys, Values and Items](#keys-values-and-items)
+    - [Iterators](#iterators)
+    - [Sorted slices](#sorted-slices)
+  - [Nested maps](#nested-maps)
+    - [Inserting values](#inserting-values)
+    - [Fetching values](#fetching-values)
+    - [Deleting values](#deleting-values)
 
 ## Tuple
 
@@ -387,3 +394,79 @@ func newIterSlice[T any](slice []T) Iterator[T] {
 ## Maps
 
 The `maps` package contains a number of utility functions that work over maps, including getting a slice of the Keys or Values of a map.
+
+### Keys, Values and Items
+The `Keys` function can be used to collect the keys of a map into a slice, e.g:
+
+```go
+m := map[string]int{"one": 1, "two": 2}
+k := maps.Keys(m) // []string{"one","two"}
+```
+
+Similarly, the `Values` function will collect the values:
+
+```go
+v := maps.Values(m) // []int{1,2}
+```
+
+If you need both keys and values, the `Items` function will return a slice of `tuple.Tuple2` values with each tuple holding a key/value pair, e.g:
+```go
+i := maps.Items(m) // []tuple.Tuple2[string,int] { {"one",1}, {"two",2} }
+```
+
+Note that in all three cases, the ordering of the slice returned is undefined.
+
+#### Iterators
+For each of the these three functions, there exists three variants,  `IterKeys`, `IterValues` and `IterItems`, which return iterators rather than slices. The ordering for these iterators is also undefined.
+
+#### Sorted slices
+The slice returning functions also have ordered alternatives, `SortedKeys`, `SortedValuesByKey` and `SortedItems`, which return keys, values and items sorted in key order.
+
+### Nested maps
+A group of functions are available for managing nested maps, that is maps whose values may also be maps, and which have the signature `map[K comparable]any`. A common concrete example is `map[string]any`, which is useful for un-marshaling arbitrary YAML or JSON documents.
+
+All the functions take a map with the generic signature above, and a list of elements of type K which represent a path into the map. For example a list consisting of `[]string{"a","b","c"}` describes the value found by first looking up "a" in a map with `string` keys, expecting to find another map value of the same type, then looking up "b" in that map, again expecting a map result, and then finally looking up "c" in that final map.
+
+#### Inserting values
+The `PutPath` function will insert or mutate a key in the map. Any missing intermediate levels of map will be created as necessary, except the top level; the map provided cannot be nil. For example:
+
+```go
+m := make(map[string]any)
+maps.PutPath(m, []string{"a", "b"}, 123)
+// m is map[string]any{	"a": map[string]any{"b": 123}}
+```
+
+Once an item has been established as either a map or non-map value, it cannot be replaced by a value of the opposite kind, for example:
+
+```go
+err := maps.PutPath(m, []string{"a"}, 456)
+errors.Is(err,maps.ErrPathConflict) // true
+```
+
+#### Fetching values
+The `GetPath` function will fetch a value at a location in the nested map, defined by a slice of keys. It returns the value found and an error.
+
+```go
+m := map[string]any {"a": map[string]any { "b": 123 }}
+v, _ := maps.GetPath(m, []string{"a","b"}) // v == 123
+```
+
+If the specified path does not exist, then a `maps.ErrKeyError` error will be returned.
+
+```go
+_, err := maps.GetPath(m, []string{"a","c"})     // errors.Is(err,maps.ErrKeyError)
+_, err := maps.GetPath(m, []string{"a","b","c"}) // errors.Is(err,maps.ErrKeyError)
+```
+
+#### Deleting values
+The `DeletePath` function will delete an item from a nested map, located by a path consisting of a slice of keys. It can delete a leaf value or an interior map, thereby removing a subtree. If a map becomes empty as a result of deleting a key from it, it itself is deleted from the parent map. This process recurses towards the root of the tree as many times as necessary.
+
+```go
+m := map[string]any{
+  "one": 1,
+  "two": map[string]any{
+    "three": 23,
+  },
+}
+maps.DeletePath(m,[]string{"two","three"}) // m == map[string]any{"one": 1 }
+```

--- a/maps/maps.go
+++ b/maps/maps.go
@@ -59,15 +59,16 @@ func NewPathNotFound[K comparable](path []K) PathNotFound[K] {
 
 // PutPath puts a value in a (possibly) nested map of maps. It mutates a map
 // whose type signature maps from a comparable key to a value, where that value
-// can include a nested map with the same type signature. The path argument is
-// a list of keys,  each one representing a key at consecutive levels in the map.
+// can include a nested map with the same type signature. The map can be empty, but
+// it cannot be nil. The path argument is
+// a list of keys, each one representing a key at consecutive levels in the map.
 // Intermediate maps are created as necessary. It is an error to attempt to replace
 // an existing map with another value, or to replace an existing non-map value with a map.
 //
-//		m := make(map[string]any)
-//		PutPath(m, []string{"a", "b"}, 123)
-//		// m contains map[string]any{ "a": map[string]any{"b": 123} }
-//	  err := PutPath([]string{"a"}, 456, m) // err != nil
+//	m := make(map[string]any)
+//	PutPath(m, []string{"a", "b"}, 123)
+//	// m contains map[string]any{ "a": map[string]any{"b": 123} }
+//	err := PutPath([]string{"a"}, 456, m) // err != nil
 func PutPath[K comparable](top map[K]any, path []K, value any) error {
 	m := top
 	for i, s := range path {
@@ -142,7 +143,18 @@ func DeletePath[K comparable](top map[K]any, path []K) (result any, ok bool, err
 	return
 }
 
-func GetPath[K comparable](path []K, top map[K]any) (result any, err error) {
+// GetPath fetches a value from a (possibly) nested map of maps. It traverses a map
+// whose type signature maps from a comparable key to a value, where that value
+// can include a nested map with the same type signature. The path argument is
+// a list of keys, each one representing a key at consecutive levels in the map.
+// This function looks up each key in turn at consecutive levels of the nested maps
+// and returns the value found after the last key lookup. This may be a leaf value or
+// an interior map node. If any of the key lookups fail, a PathNotFound error is
+// returned indicating which key lookup failed.
+//
+//	m := map[string]any{ "a": map[string]any{"b": 123 } }
+//	GetPath(m,[]string{"a","b"}) // 123
+func GetPath[K comparable](top map[K]any, path []K) (result any, err error) {
 	m := top
 	result = any(top)
 	for i, s := range path {

--- a/slices/slices.go
+++ b/slices/slices.go
@@ -420,6 +420,7 @@ func (sbf SortableByFunction[T]) Less(i, j int) bool {
 // Sorts a slice by using a function to determine ordering. The
 // less parameter is a function of two elements of type T that should
 // return true if the first is less then (should be ordered before) the second.
+// The slice is sorted in place.
 func SortUsing[T any](slice []T, less func(T, T) bool) {
 	sort.Sort(SortableByFunction[T]{slice, less})
 }


### PR DESCRIPTION
Documentation update for maps package.

Breaking: change parameter order on `maps.GetPath` function to be in line with other nested map functions. 