### PR TITLE
Add a stack trace to test.ReportErr

### DIFF
--- a/errors/handler/handler.go
+++ b/errors/handler/handler.go
@@ -27,9 +27,22 @@
 // can recovered via the Catch() or Handle() functions.
 package handler
 
-import "fmt"
+import (
+	"fmt"
+	"reflect"
+)
 
-// Removes the error value from a return value.
+var packageName string
+
+// PackageName returns the pull path of this package
+func PackageName() string {
+	if packageName == "" {
+		packageName = reflect.TypeOf(TryError{}).PkgPath()
+	}
+	return packageName
+}
+
+// Must removes the error value from a return value.
 // Panics if err is non-nil, otherwise returns the value
 // e.g.
 //
@@ -116,13 +129,13 @@ func Catch(retErr *error) {
 // such as wrapping the error in another error type.
 // e.g.
 //
-//    func readFileWrapErr(fname string) (content []byte, err error) {
-//      defer Handle(func(e error) {
-//        err = fmt.Errorf("Error reading %s: %w", fname, e)
-//      })
-//      content = Try(os.ReadFile(fname))
-//      return
-//    }
+//	func readFileWrapErr(fname string) (content []byte, err error) {
+//	  defer Handle(func(e error) {
+//	    err = fmt.Errorf("Error reading %s: %w", fname, e)
+//	  })
+//	  content = Try(os.ReadFile(fname))
+//	  return
+//	}
 func Handle(handler func(err error)) {
 	if err := recover(); err != nil {
 		if tryErr, ok := err.(TryError); ok {

--- a/errors/result/result.go
+++ b/errors/result/result.go
@@ -7,11 +7,20 @@ package result
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/robdavid/genutil-go/errors/handler"
 )
 
-//import "github.com"
+var packageName string
+
+// PackageName returns the pull path of this package
+func PackageName() string {
+	if packageName == "" {
+		packageName = reflect.TypeOf(Result[bool]{}).PkgPath()
+	}
+	return packageName
+}
 
 // Contains a value of type T, and/or an error
 type Result[T any] struct {

--- a/errors/test/test.go
+++ b/errors/test/test.go
@@ -5,6 +5,7 @@ package test
 import (
 	"errors"
 	"fmt"
+	"runtime"
 	"strings"
 
 	"github.com/robdavid/genutil-go/errors/handler"
@@ -15,6 +16,7 @@ import (
 // An interface implemented by multiple types in the "testing" package
 type TestReporting interface {
 	Error(args ...any)
+	Errorf(format string, args ...any)
 	FailNow()
 	Helper()
 }
@@ -105,6 +107,81 @@ func (r *TestableResult[T]) FailsContaining(t TestReporting, expected string) *T
 	return r
 }
 
+type stackFrame struct {
+	file     string
+	line     int
+	function string
+}
+
+func (frame *stackFrame) String() string {
+	return fmt.Sprintf("%s:%d %s", frame.file, frame.line, frame.function)
+}
+
+func (frame *stackFrame) packageName() string {
+	packageLast := strings.LastIndex(frame.function, "/")
+	if packageLast < 0 {
+		return frame.function
+	}
+	functionStart := strings.Index(frame.function[packageLast:], ".")
+	if functionStart < 0 {
+		return frame.function
+	}
+	return frame.function[:packageLast+functionStart]
+}
+
+func callStack(size int) []stackFrame {
+	callers := make([]uintptr, size)
+	n := runtime.Callers(1, callers)
+	frames := runtime.CallersFrames(callers[:n])
+	stackFrames := make([]stackFrame, 0, n)
+	for frame, _ := frames.Next(); frame.PC != 0; frame, _ = frames.Next() {
+		stackFrames = append(stackFrames, stackFrame{
+			file:     frame.File,
+			line:     frame.Line,
+			function: frame.Function,
+		})
+	}
+	return stackFrames
+}
+
+func trimCallStack(frames []stackFrame) []stackFrame {
+	const (
+		lookForTry = iota
+		lookForEndOfHandling
+	)
+	lookFor := lookForTry
+	tryFuntionPath := handler.PackageName() + ".Try"
+	for i, frame := range frames {
+		switch lookFor {
+		case lookForTry:
+			// Look for Try frame
+			if strings.HasPrefix(frame.function, tryFuntionPath) {
+				lookFor = lookForEndOfHandling
+			}
+		case lookForEndOfHandling:
+			// Look for end of calls in handler or result package
+			pkg := frame.packageName()
+			if pkg != handler.PackageName() &&
+				pkg != result.PackageName() {
+				return frames[i:]
+			}
+		}
+	}
+	return frames
+}
+
+const maxStackDepth = 255
+
+func logStack(t TestReporting) {
+	frames := callStack(maxStackDepth)
+	frames = trimCallStack(frames)
+	var trace strings.Builder
+	for _, frame := range frames {
+		fmt.Fprintln(&trace, frame.String())
+	}
+	t.Errorf("stack trace\n%s\n", trace.String())
+}
+
 // Reports any error encountered in a call to Try().
 // Should be used as part of a defer call.
 // e.g.
@@ -113,6 +190,7 @@ func (r *TestableResult[T]) FailsContaining(t TestReporting, expected string) *T
 //	f := Try(os.Open(myfile))
 func ReportErr(t TestReporting) {
 	t.Helper()
+	logStack(t)
 	if err := recover(); err != nil {
 		if tryErr, ok := err.(handler.TryError); ok {
 			t.Error(tryErr.Error)


### PR DESCRIPTION
The error location reported by `test.ReportErr`  unhelpfully reports the location that the panic was raised from, inside the library. This change adds printing of a stack trace which starts at the location where the error is raised by `Try`.