### PR TITLE
Potentially breaking changes to improve the safety of list.List and lmap.LinkedMap

### DIFF
--- a/iterator/empty.go
+++ b/iterator/empty.go
@@ -27,3 +27,11 @@ func Empty[T any]() Iterator[T] {
 func Empty2[K any, V any]() Iterator2[K, V] {
 	return NewDefaultIterator2(emptyIter2[K, V]{})
 }
+
+func EmptySeq[T any]() iter.Seq[T] {
+	return func(func(T) bool) {}
+}
+
+func EmptySeq2[K any, V any]() iter.Seq2[K, V] {
+	return func(func(K, V) bool) {}
+}

--- a/list/doc.go
+++ b/list/doc.go
@@ -1,16 +1,20 @@
 /*
-The list package provides a double linked list. Compared with some other
-list or vector implementations where the list behaves as if an array, indexed at
-zero, this has some different characteristics.
+The list package provides a double linked list. The list consists of a series of
+linked nodes, which may be accessed, traversed, retained etc. independently of
+the list in which they are a member. The caller may obtain a pointer to a node
+from an arbitrary position in the list and this node will remain valid unless
+deleted from the list. Traversal operations can be performed with a node pointer
+alone; mutations require the containing list object as well.
 
-  - Any [List] object represents a list. The list may be empty.
-  - A [List] object does not necessarily refer to the start of a list; it may
-    be pointing at any point within a list, or even the end.
-  - It it possible to iterate both backwards and forwards over the list. See [List.Next], [List.Prev] or
-    [List.Seq] and [List.RevSeq] for example.
-  - Items can be numerically indexed, both by positive or negative indexes. Access to items at index n
-    or -n takes place in O(n) time.
-  - As well as methods to access elements, many access methods return new lists as a result. See, for example,
-    the [List.At] method.
+Values in the list may be accessed by index or iteration; note that index access
+is an O(n) operation requiring traversal of the list (n being the index value).
+
+The list is "pointer-like" in that a value copy of a list actually refers to the
+original list, with mutations being reflected in both copies. The zero value is
+a nil list that contains no elements that can be read like an empty list but
+cannot be mutated. This is similar to the native map object. The rationale for
+this is that a "value-like" copy can result in an inconsistent state once
+mutations are performed, and a zero value can only carry a nil pointer. Non-nil
+lists are created with the Make function (or other constructors).
 */
 package list

--- a/list/list.go
+++ b/list/list.go
@@ -143,6 +143,18 @@ func (lst List[T]) Make() List[T] {
 	return Make[T]()
 }
 
+// Returns true if the list is "nil", its uninitialized zero value.
+// Such a list behaves like an empty list for read operations, and will
+// panic on write operations.
+func (lst List[T]) IsNil() bool {
+	return lst.inner == nil
+}
+
+// IsEmpty returns true if the list is empty
+func (lst List[T]) IsEmpty() bool {
+	return lst.inner == nil || lst.first == nil
+}
+
 // Len returns the number of elements in the list
 func (lst List[T]) Len() int {
 	if lst.inner == nil {
@@ -321,13 +333,17 @@ func From[T any](itr iterator.Iterator[T]) List[T] {
 	}
 }
 
-func As[U ~struct{ List[T] }, T any](l List[T]) U {
-	return U{l}
+// Clone creates a shallow copy of the list. Cloning a nil list will return
+// a nil list.
+func (lst List[T]) Clone() List[T] {
+	if lst.inner == nil {
+		return List[T]{}
+	}
+	return FromSeq(lst.Seq())
 }
 
-// IsEmpty returns true if the list is empty
-func (lst List[T]) IsEmpty() bool {
-	return lst.inner == nil || lst.first == nil
+func As[U ~struct{ List[T] }, T any](l List[T]) U {
+	return U{l}
 }
 
 // First returns the first node in the list that this node is a member of, found

--- a/list/list.go
+++ b/list/list.go
@@ -2,14 +2,18 @@ package list
 
 import (
 	"errors"
+	"fmt"
 	"iter"
+	"strings"
 
+	"github.com/robdavid/genutil-go/functions"
 	"github.com/robdavid/genutil-go/iterator"
 	"github.com/robdavid/genutil-go/option"
 )
 
 var ErrIndexError = errors.New("index out of bounds")
 var ErrNilNode = errors.New("node is nil")
+var ErrNilList = errors.New("list is nil")
 
 // Node is an element within a doubly linked list.
 type Node[T any] struct {
@@ -103,23 +107,27 @@ func (node *Node[T]) RevIterNode() iterator.Iterator[*Node[T]] {
 // NodeToValue is a helper function that extracts the value from a node.
 func NodeToValue[T any](node *Node[T]) T { return node.value }
 
+type inner[T any] struct {
+	first, last *Node[T]
+	size        int
+}
+
 // List is a doubly linked list. More precisely it may reference any given element within such a list, which
 // may be at the beginning, the end, or any point in between. The list can be traversed in either
 // direction. The list may be empty, in which case it references nothing.
 
 type List[T any] struct {
-	first, last *Node[T]
-	size        int
+	*inner[T]
 }
 
 // Make creates a new empty list
 func Make[T any]() List[T] {
-	return List[T]{nil, nil, 0}
+	return List[T]{&inner[T]{nil, nil, 0}}
 }
 
 // New returns a pointer to a new empty list
 func New[T any]() *List[T] {
-	return &List[T]{nil, nil, 0}
+	return &List[T]{&inner[T]{nil, nil, 0}}
 }
 
 // Of creates a new list whose elements are taken from the variadic args of the function
@@ -130,20 +138,34 @@ func Of[T any](slice ...T) List[T] {
 	return lst
 }
 
+// Make returns an empty, non-nil, [List][T] instance.
+func (lst List[T]) Make() List[T] {
+	return Make[T]()
+}
+
 // Len returns the number of elements in the list
 func (lst List[T]) Len() int {
-	return lst.size
+	if lst.inner == nil {
+		return 0
+	} else {
+		return lst.size
+	}
 }
 
 // Clear removes all elements from the list
-func (lst *List[T]) Clear() {
-	lst.first = nil
-	lst.last = nil
-	lst.size = 0
+func (lst List[T]) Clear() {
+	if lst.inner != nil {
+		lst.first = nil
+		lst.last = nil
+		lst.size = 0
+	}
 }
 
 // Append adds the provided elements to the end of the list
-func (lst *List[T]) Append(slice ...T) {
+func (lst List[T]) Append(slice ...T) {
+	if lst.inner == nil {
+		panic(ErrNilList)
+	}
 	start, end := Chain(slice...)
 	if lst.first == nil {
 		lst.first = start
@@ -157,7 +179,10 @@ func (lst *List[T]) Append(slice ...T) {
 }
 
 // Prepend adds the provided elements to the start of the list
-func (lst *List[T]) Prepend(slice ...T) {
+func (lst List[T]) Prepend(slice ...T) {
+	if lst.inner == nil {
+		panic(ErrNilList)
+	}
 	start, end := Chain(slice...)
 	if lst.first == nil {
 		lst.first = start
@@ -172,26 +197,41 @@ func (lst *List[T]) Prepend(slice ...T) {
 
 // Seq returns a native iter.Seq iterator over element values moving forwards in the list.
 func (lst List[T]) Seq() iter.Seq[T] {
+	if lst.inner == nil {
+		return iterator.EmptySeq[T]()
+	}
 	return lst.first.Seq()
 }
 
 // RevSeq returns a native iter.Seq iterator over element values moving backwards in the list.
 func (lst List[T]) RevSeq() iter.Seq[T] {
+	if lst.inner == nil {
+		return iterator.EmptySeq[T]()
+	}
 	return lst.last.RevSeq()
 }
 
 // SeqNode returns a native iter.Seq iterator over element nodes moving forwards in the list.
 func (lst List[T]) SeqNode() iter.Seq[*Node[T]] {
+	if lst.inner == nil {
+		return iterator.EmptySeq[*Node[T]]()
+	}
 	return lst.first.SeqNode()
 }
 
 // RevSeqNode returns a native iter.Seq iterator over element nodes moving backwards in the list.
 func (lst List[T]) RevSeqNode() iter.Seq[*Node[T]] {
+	if lst.inner == nil {
+		return iterator.EmptySeq[*Node[T]]()
+	}
 	return lst.last.RevSeqNode()
 }
 
 // Iter returns an iterator over element values moving forwards in the list.
 func (lst List[T]) Iter() iterator.Iterator[T] {
+	if lst.inner == nil {
+		return iterator.Empty[T]()
+	}
 	remain := lst.size
 	return iterator.NewWithSize(
 		func(yield func(T) bool) {
@@ -208,6 +248,9 @@ func (lst List[T]) Iter() iterator.Iterator[T] {
 
 // IterNode returns an iterator over element nodes moving forwards in the list.
 func (lst List[T]) IterNode() iterator.Iterator[*Node[T]] {
+	if lst.inner == nil {
+		return iterator.Empty[*Node[T]]()
+	}
 	remain := lst.size
 	return iterator.NewWithSize(
 		func(yield func(*Node[T]) bool) {
@@ -229,6 +272,9 @@ func (lst List[T]) RevIter() iterator.Iterator[T] {
 
 // RevIter returns an iterator over element nodes moving backwards through the list
 func (lst List[T]) RevIterNode() iterator.Iterator[*Node[T]] {
+	if lst.inner == nil {
+		return iterator.Empty[*Node[T]]()
+	}
 	remain := lst.size
 	return iterator.NewWithSize(
 		func(yield func(*Node[T]) bool) {
@@ -241,6 +287,16 @@ func (lst List[T]) RevIterNode() iterator.Iterator[*Node[T]] {
 		},
 		func() iterator.IteratorSize { return iterator.NewSize(remain) },
 	)
+}
+
+func (lst List[T]) String() string {
+	var str strings.Builder
+	str.WriteRune('[')
+	for i, v := range lst.Iter().Enumerate().Seq2() {
+		fmt.Fprintf(&str, "%s%v", functions.IfElse(i == 0, "", " "), v)
+	}
+	str.WriteRune(']')
+	return str.String()
 }
 
 // FromSeq creates a new list whose elements are taken from the supplied iter.Seq iterator.
@@ -271,7 +327,7 @@ func As[U ~struct{ List[T] }, T any](l List[T]) U {
 
 // IsEmpty returns true if the list is empty
 func (lst List[T]) IsEmpty() bool {
-	return lst.first == nil
+	return lst.inner == nil || lst.first == nil
 }
 
 // First returns the first node in the list that this node is a member of, found
@@ -339,6 +395,9 @@ func (lst List[T]) Get(n int) T {
 // may be negative as well as positive, or zero (the first element). If
 // negative, it counts as an offset from the end of the list plus one.
 func (lst List[T]) At(n int) *Node[T] {
+	if lst.inner == nil {
+		panic(ErrIndexError)
+	}
 	if n < 0 {
 		return lst.last.At(n + 1)
 	} else {
@@ -350,7 +409,7 @@ func (lst List[T]) At(n int) *Node[T] {
 // of the list; n may be negative as well as positive, or zero (the first
 // element). If negative, it counts as an offset from the end of the list plus
 // one.
-func (lst *List[T]) Set(n int, value T) {
+func (lst List[T]) Set(n int, value T) {
 	lst.At(n).Set(value)
 }
 
@@ -358,7 +417,7 @@ func (lst *List[T]) Set(n int, value T) {
 // empty, an empty option is returned; otherwise it will hold the element's
 // value.
 func (lst List[T]) GetFirst() option.Option[T] {
-	if lst.first == nil {
+	if lst.inner == nil || lst.first == nil {
 		return option.Empty[T]()
 	} else {
 		return option.Value(lst.first.value)
@@ -369,7 +428,7 @@ func (lst List[T]) GetFirst() option.Option[T] {
 // empty, an empty option is returned; otherwise it will hold the element's
 // value.
 func (lst List[T]) GetLast() option.Option[T] {
-	if lst.last == nil {
+	if lst.inner == nil || lst.last == nil {
 		return option.Empty[T]()
 	} else {
 		return option.Value(lst.last.value)
@@ -378,17 +437,23 @@ func (lst List[T]) GetLast() option.Option[T] {
 
 // First returns the first node of the list.
 func (lst List[T]) First() *Node[T] {
+	if lst.inner == nil {
+		return nil
+	}
 	return lst.first
 }
 
 // Last returns the last node of the list.
 func (lst List[T]) Last() *Node[T] {
+	if lst.inner == nil {
+		return nil
+	}
 	return lst.last
 }
 
 // Insert inserts new elements before the given node, moving the original element to following
 // position.
-func (lst *List[T]) Insert(node *Node[T], values ...T) {
+func (lst List[T]) Insert(node *Node[T], values ...T) {
 	start, end := Chain(values...)
 	if start == nil || end == nil {
 		return
@@ -412,7 +477,7 @@ func (lst *List[T]) Insert(node *Node[T], values ...T) {
 
 // Insert inserts new elements after the given node, moving the previously following elements to after
 // the inserted ones.
-func (lst *List[T]) InsertAfter(node *Node[T], values ...T) {
+func (lst List[T]) InsertAfter(node *Node[T], values ...T) {
 	start, end := Chain(values...)
 	if start == nil || end == nil {
 		return
@@ -457,7 +522,7 @@ func (node *Node[T]) Set(value T) bool {
 
 // Delete removes a node from the list. If there is only one element in the list, the
 // result will be the empty list.
-func (lst *List[T]) Delete(node *Node[T]) {
+func (lst List[T]) Delete(node *Node[T]) {
 	if node == nil {
 		return
 	}

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -10,16 +10,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEmpty(t *testing.T) {
-	var empty list.List[int]
-	assert.Equal(t, 0, empty.Len())
-	assert.True(t, empty.IsEmpty())
-	assert.Empty(t, empty.Iter().Collect())
-	assert.Empty(t, empty.RevIter().Collect())
-	assert.Empty(t, empty.IterNode().Collect())
-	assert.Empty(t, empty.RevIterNode().Collect())
-	assert.True(t, empty.GetFirst().ToRef().IsEmpty())
-	assert.True(t, empty.GetLast().ToRef().IsEmpty())
+func TestNil(t *testing.T) {
+	var zero list.List[int]
+	assert.True(t, zero.IsNil())
+	assert.True(t, zero.IsEmpty())
+	assert.Equal(t, 0, zero.Len())
+	assert.Empty(t, zero.Iter().Collect())
+	assert.Empty(t, zero.RevIter().Collect())
+	assert.Empty(t, zero.IterNode().Collect())
+	assert.Empty(t, zero.RevIterNode().Collect())
+	assert.True(t, zero.GetFirst().ToRef().IsEmpty())
+	assert.True(t, zero.GetLast().ToRef().IsEmpty())
 }
 
 func TestOf(t *testing.T) {
@@ -111,6 +112,19 @@ func TestPrependSlice(t *testing.T) {
 	expected := slices.Range(0, size)
 	assert.Equal(t, expected, list.Iter().Collect())
 	assert.Equal(t, slices.Reverse(expected), list.RevIter().Collect())
+}
+
+func TestCopyClone(t *testing.T) {
+	l1 := list.New[string]()
+	l2 := l1
+	l2.Append("first")
+	assert.Equal(t, l2.Get(0), "first")
+	assert.Equal(t, l1.Get(0), "first")
+	l3 := l1.Clone()
+	l1.Append("last")
+	l3.Append("second")
+	assert.Equal(t, l3.Get(1), "second")
+	assert.Equal(t, l1.Get(1), "last")
 }
 
 func TestInsertNothing(t *testing.T) {

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -1,6 +1,7 @@
 package list_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/robdavid/genutil-go/iterator"
@@ -44,6 +45,11 @@ func TestClear(t *testing.T) {
 	assert.Equal(t, 0, lst.Len())
 }
 
+func TestString(t *testing.T) {
+	lst := list.Of(1, 2, 3, 4)
+	assert.Equal(t, fmt.Sprintf("%v", lst.Iter().Collect()), fmt.Sprintf("%v", lst))
+}
+
 func TestAppend(t *testing.T) {
 	const size = 10
 	list := list.Make[int]()
@@ -54,6 +60,16 @@ func TestAppend(t *testing.T) {
 	expected := slices.Range(0, size)
 	assert.Equal(t, expected, list.Iter().Collect())
 	assert.Equal(t, slices.Reverse(expected), list.RevIter().Collect())
+}
+
+func TestAppendNil(t *testing.T) {
+	var lst list.List[int]
+	assert.PanicsWithError(t, list.ErrNilList.Error(), func() {
+		lst.Append(1)
+	})
+	lst = lst.Make()
+	lst.Append(1)
+	assert.Equal(t, []int{1}, lst.Iter().Collect())
 }
 
 func TestAppendSlice(t *testing.T) {
@@ -77,6 +93,13 @@ func TestPrepend(t *testing.T) {
 	expected := slices.Range(0, size)
 	assert.Equal(t, expected, list.Iter().Collect())
 	assert.Equal(t, slices.Reverse(expected), list.RevIter().Collect())
+}
+
+func TestPrependNil(t *testing.T) {
+	assert.PanicsWithError(t, list.ErrNilList.Error(), func() {
+		var lst list.List[int]
+		lst.Prepend(1)
+	})
 }
 
 func TestPrependSlice(t *testing.T) {
@@ -183,7 +206,7 @@ func TestLenAndCount(t *testing.T) {
 	const insSize = 10
 	const iterations = 20
 	const deletions = 50
-	var lst list.List[int]
+	lst := list.New[int]()
 	insSlice := slices.Range(0, insSize)
 	lst.Append(insSlice...)
 	for range iterations {
@@ -208,7 +231,7 @@ func TestFirstLast(t *testing.T) {
 
 func TestGetSetAt(t *testing.T) {
 	const size = 10
-	var lst list.List[int]
+	lst := list.New[int]()
 	for range size {
 		lst.Append(0)
 	}
@@ -407,8 +430,18 @@ func TestDeleteLast(t *testing.T) {
 	assert.Equal(t, slices.Reverse(expected), lst.RevIter().Collect())
 }
 
+func BenchmarkAppend(b *testing.B) {
+	lst := list.Make[int]()
+	for i := range b.N {
+		lst.Append(i)
+	}
+	if lst.Len() != b.N {
+		b.Errorf("Expecting length %d, got %d", b.N, lst.Len())
+	}
+}
+
 func BenchmarkIter(b *testing.B) {
-	var lst list.List[int]
+	lst := list.Make[int]()
 	for i := range b.N {
 		lst.Append(i)
 	}
@@ -423,7 +456,7 @@ func BenchmarkIter(b *testing.B) {
 }
 
 func BenchmarkIterCollect(b *testing.B) {
-	var lst list.List[int]
+	lst := list.New[int]()
 	for i := range b.N {
 		lst.Append(i)
 	}
@@ -435,7 +468,7 @@ func BenchmarkIterCollect(b *testing.B) {
 }
 
 func BenchmarkSeq(b *testing.B) {
-	var lst list.List[int]
+	lst := list.New[int]()
 	for i := range b.N {
 		lst.Append(i)
 	}
@@ -450,7 +483,7 @@ func BenchmarkSeq(b *testing.B) {
 }
 
 func BenchmarkSeqCollect(b *testing.B) {
-	var lst list.List[int]
+	lst := list.Make[int]()
 	for i := range b.N {
 		lst.Append(i)
 	}

--- a/lmap/lmap.go
+++ b/lmap/lmap.go
@@ -89,7 +89,7 @@ func (lm LinkedMap[K, V]) IsEmpty() bool {
 
 // Put places a key and value pair into the map, either adding it as a new
 // entry if the key is not already in the map, or replacing an existing one.
-func (lm *LinkedMap[K, V]) Put(k K, v V) {
+func (lm LinkedMap[K, V]) Put(k K, v V) {
 	if current, ok := lm.kv[k]; ok {
 		current.value = v
 		lm.kv[k] = current
@@ -178,7 +178,7 @@ func (lm LinkedMap[K, V]) IterValues() iterator.Iterator[V] {
 }
 
 // Delete removes the key from the map and returns the associated value and whether the key was present.
-func (lm *LinkedMap[K, V]) Delete(k K) (V, bool) {
+func (lm LinkedMap[K, V]) Delete(k K) (V, bool) {
 	val, ok := lm.kv[k]
 	if ok {
 		lm.keys.Delete(val.node)

--- a/lmap/lmap_test.go
+++ b/lmap/lmap_test.go
@@ -23,14 +23,8 @@ func TestZero(t *testing.T) {
 	var lm lmap.LinkedMap[string, int]
 	assert.True(t, lm.IsEmpty())
 	assert.Equal(t, 0, lm.Len())
-	z, ok := lm.Delete("one")
-	assert.False(t, ok)
-	assert.Equal(t, 0, z)
 	assert.Empty(t, lm.IterKeys().Collect())
 	assert.Empty(t, lm.Iter().Collect2())
-	lm.Put("one", 1)
-	assert.False(t, lm.IsEmpty())
-	assert.Equal(t, 1, lm.Len())
 }
 
 func TestPutGet(t *testing.T) {
@@ -44,6 +38,9 @@ func TestPutGet(t *testing.T) {
 	val, ok := lm.GetOk("two")
 	assert.True(t, ok)
 	assert.Equal(t, 2, val)
+	lm2 := lm
+	assert.Equal(t, 1, lm2.Get("one"))
+	assert.Equal(t, 2, lm2.Get("two"))
 }
 
 func TestInsertOrder(t *testing.T) {

--- a/lmap/lmap_test.go
+++ b/lmap/lmap_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/robdavid/genutil-go/functions"
 	"github.com/robdavid/genutil-go/iterator"
+	"github.com/robdavid/genutil-go/list"
 	"github.com/robdavid/genutil-go/lmap"
 	"github.com/robdavid/genutil-go/slices"
 	"github.com/stretchr/testify/assert"
@@ -25,6 +26,10 @@ func TestZero(t *testing.T) {
 	assert.Equal(t, 0, lm.Len())
 	assert.Empty(t, lm.IterKeys().Collect())
 	assert.Empty(t, lm.Iter().Collect2())
+	assert.Equal(t, "lmap[]", lm.String())
+	assert.PanicsWithError(t, list.ErrNilList.Error(), func() {
+		lm.Put("zero", 0)
+	})
 }
 
 func TestPutGet(t *testing.T) {
@@ -123,6 +128,16 @@ func TestReplaceValues(t *testing.T) {
 	for k, v := range lm.Seq2() {
 		assert.Equal(t, k+100, v)
 	}
+}
+
+func TestString(t *testing.T) {
+	values := []string{"zero", "one", "two", "three", "four"}
+	lm := lmap.FromIterKeys(iterator.Range(0, len(values)), slices.AsFunc(values))
+	m := map[int]string{}
+	for i, v := range values {
+		m[i] = v
+	}
+	assert.Equal(t, fmt.Sprintf("l%v", m), fmt.Sprintf("%v", lm))
 }
 
 func Benchmark(b *testing.B) {

--- a/slices/slices.go
+++ b/slices/slices.go
@@ -386,6 +386,13 @@ func AllRef[T any](slice []T, predicate func(v *T) bool) bool {
 	return true
 }
 
+// Generate a function equivalent to indexing slice, mapping indexes to values.
+func AsFunc[T any](slice []T) func(int) T {
+	return func(i int) (v T) {
+		return slice[i]
+	}
+}
+
 // Returns true if predicate returns true for at least one element in
 // slice.
 func Any[T any](slice []T, predicate func(v T) bool) bool {


### PR DESCRIPTION
* Both list.List and lmap.LinkedMap are now inherently  "pointer-like",  and value copies are like copying pointers (similar to native map).
* Their zero values are read-only and empty (again, similar to native map).
* This is an effort to stabilize the API, but further changes are still possible, so they still carry an experimental caveat.
