### PR TITLE
Handle pointer to Stringer case in opt String()

### DIFF
--- a/opt/opt.go
+++ b/opt/opt.go
@@ -576,6 +576,9 @@ func (r Ref[T]) GetAnyOK() (any, bool) {
 // or an empty string if the option is empty.
 func (v Val[T]) String() string {
 	if v.nonEmpty {
+		if str, ok := any(&v.value).(fmt.Stringer); ok {
+			return str.String()
+		}
 		return fmt.Sprint(v.value)
 	} else {
 		return ""
@@ -586,6 +589,9 @@ func (v Val[T]) String() string {
 // or an empty string if the option is empty.
 func (r Ref[T]) String() string {
 	if r.reference != nil {
+		if str, ok := any(r.reference).(fmt.Stringer); ok {
+			return str.String()
+		}
 		return fmt.Sprint(*r.reference)
 	} else {
 		return ""

--- a/opt/opt_test.go
+++ b/opt/opt_test.go
@@ -289,6 +289,14 @@ func TestDeepEqual(t *testing.T) {
 	assert.False(opt.DeepEqual(val1, val3))
 }
 
+type stringerPtrStruct struct{}
+
+func (*stringerPtrStruct) String() string { return "this is stringerPtrStruct" }
+
+type stringerStruct struct{}
+
+func (stringerStruct) String() string { return "this is stringerStruct" }
+
 func TestString(t *testing.T) {
 	val1 := opt.Value(123)
 	var x int = 456
@@ -303,6 +311,18 @@ func TestString(t *testing.T) {
 	assert.Equal(t, "-", emptyStr)
 	emptyStr = fmt.Sprintf("%s-%s", &empty, &emptyRef)
 	assert.Equal(t, "-", emptyStr)
+}
+
+func TestStringer(t *testing.T) {
+	assert := assert.New(t)
+	ssv := opt.Value(stringerStruct{})
+	spsv := opt.Value(stringerPtrStruct{})
+	ssr := opt.Reference(&stringerStruct{})
+	spsr := opt.Reference(&stringerPtrStruct{})
+	assert.Equal("this is stringerStruct", ssv.String())
+	assert.Equal("this is stringerPtrStruct", spsv.String())
+	assert.Equal("this is stringerStruct", ssr.String())
+	assert.Equal("this is stringerPtrStruct", spsr.String())
 }
 
 func TestTryRef(t *testing.T) {


### PR DESCRIPTION
For `opt.Val[T].String()` and `opt.Ref[T].String()`, if `*T` implements `fmt.Stringer`, return the result of calling `*T`'s String() method. 